### PR TITLE
Pass the region as an environment variable.

### DIFF
--- a/Vagrantfile.digitalocean
+++ b/Vagrantfile.digitalocean
@@ -13,7 +13,7 @@ Vagrant.configure(2) do |config|
         override.vm.box_url = "https://github.com/devopsgroup-io/vagrant-digitalocean/raw/master/box/digital_ocean.box"
         provider.token = ENV['DIGITAL_OCEAN_API_KEY']
         provider.image = 'ubuntu-16-04-x64'
-        provider.region = 'sfo1'
+        provider.region = ENV['DIGITAL_OCEAN_REGION']
         provider.size = '8gb'
         provider.ssh_key_name = ENV['DIGITAL_OCEAN_PUB_SSH']
       end


### PR DESCRIPTION
The region `sfo1` isn't available for creating droplets.